### PR TITLE
Add ClientDiagnostics API

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+name: OpenAPI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  openapi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: xml
+          coverage: none
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Composer install
+        run: composer i
+
+      - name: OpenAPI checker
+        run: |
+          composer exec generate-spec
+          if [ -n "$(git status --porcelain openapi.json)" ]; then
+            git diff
+            exit 1
+          fi

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,7 +3,7 @@ Upstream-Name: Admin overview
 Upstream-Contact: Ferdinand Thiessen <opensource@fthiessen.de>
 Source: https://github.com/nextcloud/admin_overview
 
-Files: README.md package-lock.json package.json composer.json composer.lock openapi.json
+Files: README.md package-lock.json package.json composer.json composer.lock openapi.json vendor-bin/*/composer.json vendor-bin/*/composer.lock
 Copyright: Nextcloud contributors <https://www.nextcloud.com>
 License: AGPL-3.0-or-later
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,10 +1,10 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Admin overview
 Upstream-Contact: Ferdinand Thiessen <opensource@fthiessen.de>
-Source: https://github.com/nextcloud/profiler
+Source: https://github.com/nextcloud/admin_overview
 
-Files: README.md package-lock.json package.json composer.json composer.lock
-Copyright: Ferdinand Thiessen <opensource@fthiessen.de>
+Files: README.md package-lock.json package.json composer.json composer.lock openapi.json
+Copyright: Nextcloud contributors <https://www.nextcloud.com>
 License: AGPL-3.0-or-later
 
 Files: l10n/*.js l10n/*.json

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -8,4 +8,7 @@ declare(strict_types=1);
 return [
 	'routes' => [
 	],
+	'ocs' => [
+		['name' => 'ClientDiagnostics#update', 'url' => '/diagnostics', 'verb' => 'PUT' ],
+	],
 ];

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"psalm": "psalm.phar --threads=1",
 		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline",
 		"psalm:update-baseline:force": "psalm.phar --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
-		"psalm:clear": "psalm.phar --clear-cache && psalm --clear-global-cache",
+		"psalm:clear": "psalm.phar --clear-cache && psalm.phar --clear-global-cache",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
 		"test:unit": "vendor/bin/phpunit -c tests/phpunit.xml"
 	},

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "AGPL-3.0-or-later",
 	"authors": [
 		{
-			"name": "Côme Chilliet"
+			"name": "Côme Chilliet"
 		}
 	],
 	"autoload-dev": {
@@ -27,7 +27,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/package-versions-deprecated": true
+			"composer/package-versions-deprecated": true,
+			"bamarni/composer-bin-plugin": true
 		},
 		"platform": {
 			"php": "8.0.2"
@@ -37,6 +38,7 @@
 		"phpunit/phpunit": "^9",
 		"psalm/phar": "^5.15",
 		"nextcloud/coding-standard": "^1.1",
-		"nextcloud/ocp": "dev-master"
+		"nextcloud/ocp": "dev-master",
+		"bamarni/composer-bin-plugin": "^1.8"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,14 @@
 		}
 	},
 	"scripts": {
+		"post-install-cmd": [
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || composer bin all install",
+			"composer dump-autoload"
+		],
+		"post-update-cmd": [
+			"[ $COMPOSER_DEV_MODE -eq 0 ] || composer bin all update --ansi",
+			"composer dump-autoload"
+		],
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,66 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f5b5f436cd41349936580c650c5fd58",
+    "content-hash": "1e240a37b0550f5a43d476ad650087da",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "bamarni/composer-bin-plugin",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bamarni/composer-bin-plugin.git",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "reference": "92fd7b1e6e9cdae19b0d57369d8ad31a37b6a880",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "ext-json": "*",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Bamarni\\Composer\\Bin\\BamarniBinPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Bamarni\\Composer\\Bin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "No conflicts for your bin dependencies",
+            "keywords": [
+                "composer",
+                "conflict",
+                "dependency",
+                "executable",
+                "isolation",
+                "tool"
+            ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
+            },
+            "time": "2022-10-31T08:38:03+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.5.0",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,11 +1,15 @@
 <?php
 
 declare(strict_types=1);
-// SPDX-FileCopyrightText: Ferdinand Thiessen <opensource@fthiessen.de>
-// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-FileCopyrightText: 2023 Ferdinand Thiessen <opensource@fthiessen.de>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\AdminOverview\AppInfo;
 
+use OCA\AdminOverview\Capabilities;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -21,6 +25,11 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		// Register the composer autoloader for packages shipped by this app, if applicable
 		include_once __DIR__ . '/../../vendor/autoload.php';
+
+		/*
+		 * Register capabilities
+		 */
+		$context->registerCapability(Capabilities::class);
 	}
 
 	/**

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\AdminOverview;
+
+use OCP\Capabilities\ICapability;
+
+class Capabilities implements ICapability {
+	/**
+	 * Return this classes capabilities
+	 *
+	 * @return array{admin_overview: array{diagnostics: bool}}
+	 */
+	public function getCapabilities() {
+		return [
+			'admin_overview' => [
+				'diagnostics' => true,
+			],
+		];
+	}
+}

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -44,7 +44,7 @@ class ClientDiagnosticsController extends OCSController {
 
 	/**
 	 * @param AdminOverviewProblems $problems Problems to report for this client
-	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>|DataResponse<Http::STATUS_METHOD_NOT_ALLOWED, array<empty>, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{data: array{message: string}}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>|DataResponse<Http::STATUS_METHOD_NOT_ALLOWED, array<empty>, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>
 	 *
 	 * Update a client diagnostic listing problems encountered by the client
 	 *

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\AdminOverview\Controller;
 
+use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Token\IProvider;
 use OCA\AdminOverview\Db\ClientDiagnostic;
 use OCA\AdminOverview\Db\ClientDiagnosticMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -19,8 +21,6 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Token\IProvider;
 use Psr\Clock\ClockInterface;
 
 class ClientDiagnosticsController extends OCSController {

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -3,24 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @author Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @license AGPL-3.0
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program. If not, see <http://www.gnu.org/licenses/>
- *
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\AdminOverview\Controller;
@@ -52,11 +36,9 @@ class ClientDiagnosticsController extends OCSController {
 		parent::__construct($appName, $request);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoSubAdminRequired
-	 * @NoCSRFRequired
-	 */
+	#[NoAdminRequired]
+	#[NoSubAdminRequired]
+	#[NoCSRFRequired]
 	public function update(array $problems): DataResponse {
 		try {
 			$sessionId = $this->session->getId();

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -15,6 +15,8 @@ use OCA\AdminOverview\Db\ClientDiagnostic;
 use OCA\AdminOverview\Db\ClientDiagnosticMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
@@ -37,7 +39,6 @@ class ClientDiagnosticsController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	#[NoSubAdminRequired]
 	#[NoCSRFRequired]
 	public function update(array $problems): DataResponse {
 		try {

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\AdminOverview\Controller;
 
-use OC\Authentication\Exceptions\InvalidTokenException;
-use OC\Authentication\Token\IProvider;
 use OCA\AdminOverview\Db\ClientDiagnostic;
 use OCA\AdminOverview\Db\ClientDiagnosticMapper;
 use OCA\AdminOverview\ResponseDefinitions;
@@ -20,6 +18,8 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\Authentication\Exceptions\InvalidTokenException;
+use OCP\Authentication\Token\IProvider;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;

--- a/lib/Controller/ClientDiagnosticsController.php
+++ b/lib/Controller/ClientDiagnosticsController.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\AdminOverview\Controller;
+
+use OCA\AdminOverview\Db\ClientDiagnostic;
+use OCA\AdminOverview\Db\ClientDiagnosticMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUserSession;
+use OCP\Session\Exceptions\SessionNotAvailableException;
+use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Token\IProvider;
+use Psr\Clock\ClockInterface;
+
+class ClientDiagnosticsController extends OCSController {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ISession $session,
+		private IUserSession $userSession,
+		private ClientDiagnosticMapper $mapper,
+		private IProvider $tokenProvider,
+		private ClockInterface $clock,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function update(array $problems): DataResponse {
+		try {
+			$sessionId = $this->session->getId();
+		} catch (SessionNotAvailableException $e) {
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_SERVICE_UNAVAILABLE);
+		}
+		if ($this->userSession->getImpersonatingUserID() !== null) {
+			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+
+		$appPassword = $this->session->get('app_password');
+
+		try {
+			$token = $this->tokenProvider->getToken($appPassword);
+		} catch (InvalidTokenException $e) {
+			return new DataResponse([], Http::STATUS_METHOD_NOT_ALLOWED);
+		}
+
+		/* TODO: validate problems structure */
+
+		try {
+			$entity = $this->mapper->findByAuthtokenid($token->getId());
+			$entity->setDiagnostic(json_encode(['problems' => $problems], JSON_THROW_ON_ERROR));
+			$entity->setTimestamp(\DateTime::createFromImmutable($this->clock->now()));
+			$this->mapper->update($entity);
+		} catch (DoesNotExistException $e) {
+			$entity = $this->mapper->insert(
+				ClientDiagnostic::fromParams([
+					'authtokenid' => $token->getId(),
+					'diagnostic' => json_encode(['problems' => $problems], JSON_THROW_ON_ERROR),
+					'timestamp' => \DateTime::createFromImmutable($this->clock->now()),
+				]));
+		}
+
+		return new DataResponse([]);
+	}
+}

--- a/lib/Db/ClientDiagnostic.php
+++ b/lib/Db/ClientDiagnostic.php
@@ -3,25 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @author Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\AdminOverview\Db;

--- a/lib/Db/ClientDiagnostic.php
+++ b/lib/Db/ClientDiagnostic.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AdminOverview\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setAuthtokenid(int $authtokenid)
+ * @method int getAuthtokenid()
+ * @method void setDiagnostic(string $diagnostic)
+ * @method string getDiagnostic()
+ * @method \DateTime getTimestamp()
+ * @method void setTimestamp(\DateTime $timestamp)
+ */
+class ClientDiagnostic extends Entity {
+	public const TYPE_CONFLICT = 'conflict';
+	public const TYPE_FAILED_UPLOAD = 'failed-upload';
+	public const TYPES = [
+		self::TYPE_CONFLICT,
+		self::TYPE_FAILED_UPLOAD,
+	];
+
+	/** @var int */
+	protected $authtokenid;
+
+	/** @var string json-encoded*/
+	protected $diagnostic;
+
+	/** @var \DateTime */
+	public $timestamp;
+
+	public function __construct() {
+		$this->addType('authtokenid', 'int');
+		$this->addType('diagnostic', 'string');
+		$this->addType('timestamp', 'datetime');
+	}
+
+	public function getDiagnosticAsArray(): array {
+		$data = json_decode($this->diagnostic, true, JSON_THROW_ON_ERROR);
+		return $data;
+	}
+}

--- a/lib/Db/ClientDiagnosticMapper.php
+++ b/lib/Db/ClientDiagnosticMapper.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AdminOverview\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<ClientDiagnostic>
+ */
+class ClientDiagnosticMapper extends QBMapper {
+	public const TABLE_NAME = 'client_diagnostics';
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, self::TABLE_NAME, ClientDiagnostic::class);
+	}
+
+	/**
+	 * @return ClientDiagnostic[]
+	 */
+	public function getAll(): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb
+			->select('*')
+			->from($this->getTableName());
+
+		return $this->findEntities($select);
+	}
+
+	/**
+	 * @throws DoesNotExistException
+	 */
+	public function findByAuthtokenid(int $id): ClientDiagnostic {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb
+			->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('authtokenid', $qb->createNamedParameter($id, $qb::PARAM_INT)));
+
+		return $this->findEntity($select);
+	}
+}

--- a/lib/Db/ClientDiagnosticMapper.php
+++ b/lib/Db/ClientDiagnosticMapper.php
@@ -3,25 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @author Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\AdminOverview\Db;

--- a/lib/Migration/Version00001Date20231002171502.php
+++ b/lib/Migration/Version00001Date20231002171502.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\AdminOverview\Migrations;
+namespace OCA\AdminOverview\Migration;
 
 use Closure;
 use OCA\AdminOverview\Db\ClientDiagnosticMapper;
@@ -19,7 +19,7 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Introduce client_diagnostics table
  */
-class Version28000Date20231002171502 extends SimpleMigrationStep {
+class Version00001Date20231002171502 extends SimpleMigrationStep {
 	/**
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 */

--- a/lib/Migrations/Version28000Date20231002171502.php
+++ b/lib/Migrations/Version28000Date20231002171502.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\AdminOverview\Migrations;
+
+use Closure;
+use OCA\Settings\Db\ClientDiagnosticMapper;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Introduce client_diagnostics table
+ */
+class Version28000Date20231002171502 extends SimpleMigrationStep {
+	/**
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable(ClientDiagnosticMapper::TABLE_NAME)) {
+			$table = $schema->createTable(ClientDiagnosticMapper::TABLE_NAME);
+
+			$table->addColumn('id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 64,
+				'autoincrement' => true,
+			]);
+			$table->addColumn('authtokenid', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('diagnostic', Types::TEXT, [
+				'notnull' => true,
+			]);
+			$table->addColumn('timestamp', Types::DATETIME, [
+				'notnull' => true,
+			]);
+
+			$table->setPrimaryKey(['id'], 'client_diag_id_primary');
+			$table->addUniqueIndex(['authtokenid'], 'client_diag_authtokenid_index');
+
+			$changed = true;
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migrations/Version28000Date20231002171502.php
+++ b/lib/Migrations/Version28000Date20231002171502.php
@@ -3,31 +3,14 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @author Côme Chilliet <come.chilliet@nextcloud.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\AdminOverview\Migrations;
 
 use Closure;
-use OCA\Settings\Db\ClientDiagnosticMapper;
+use OCA\AdminOverview\Db\ClientDiagnosticMapper;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
 use OCP\Migration\IOutput;

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AdminOverview;
+
+/**
+ * @psalm-type AdminOverviewProblems = array{
+ * 	conflict:array{
+ * 		count:int,
+ * 		oldest:int
+ * 	},
+ * 	failed-upload:array{
+ * 		count:int,
+ * 		oldest:int
+ * 	}
+ * }
+ */
+class ResponseDefinitions {
+}

--- a/openapi.json
+++ b/openapi.json
@@ -225,19 +225,11 @@
                                                 "data": {
                                                     "type": "object",
                                                     "required": [
-                                                        "data"
+                                                        "message"
                                                     ],
                                                     "properties": {
-                                                        "data": {
-                                                            "type": "object",
-                                                            "required": [
-                                                                "message"
-                                                            ],
-                                                            "properties": {
-                                                                "message": {
-                                                                    "type": "string"
-                                                                }
-                                                            }
+                                                        "message": {
+                                                            "type": "string"
                                                         }
                                                     }
                                                 }

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,256 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "admin_overview",
+        "version": "0.0.1",
+        "description": "Enhanced insights in your Nextcloud server",
+        "license": {
+            "name": "agpl"
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "basic_auth": {
+                "type": "http",
+                "scheme": "basic"
+            },
+            "bearer_auth": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        },
+        "schemas": {
+            "Capabilities": {
+                "type": "object",
+                "required": [
+                    "admin_overview"
+                ],
+                "properties": {
+                    "admin_overview": {
+                        "type": "object",
+                        "required": [
+                            "diagnostics"
+                        ],
+                        "properties": {
+                            "diagnostics": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                }
+            },
+            "OCSMeta": {
+                "type": "object",
+                "required": [
+                    "status",
+                    "statuscode"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    },
+                    "statuscode": {
+                        "type": "integer"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "totalitems": {
+                        "type": "string"
+                    },
+                    "itemsperpage": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Problems": {
+                "type": "object",
+                "required": [
+                    "conflict",
+                    "failed-upload"
+                ],
+                "properties": {
+                    "conflict": {
+                        "type": "object",
+                        "required": [
+                            "count",
+                            "oldest"
+                        ],
+                        "properties": {
+                            "count": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "oldest": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    },
+                    "failed-upload": {
+                        "type": "object",
+                        "required": [
+                            "count",
+                            "oldest"
+                        ],
+                        "properties": {
+                            "count": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "oldest": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "paths": {
+        "/ocs/v2.php/apps/admin_overview/diagnostics": {
+            "put": {
+                "operationId": "client_diagnostics-update",
+                "summary": "Update a client diagnostic listing problems encountered by the client",
+                "tags": [
+                    "client_diagnostics"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "problems",
+                        "in": "query",
+                        "description": "Problems to report for this client",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Diagnostic was correctly updated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "description": "Token is invalid or user is impersonated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Session was not correctly setup",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "data": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "tags": []
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,8 @@
 		xmlns="https://getpsalm.org/schema/config"
 		xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 		errorBaseline="tests/psalm-baseline.xml"
+		findUnusedBaselineEntry="true"
+		findUnusedCode="false"
 >
 	<projectFiles>
 		<directory name="lib" />
@@ -34,5 +36,9 @@
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 			</errorLevel>
 		</UndefinedDocblockClass>
+		<LessSpecificReturnStatement errorLevel="error"/>
+		<LessSpecificReturnType errorLevel="error"/>
+		<LessSpecificImplementedReturnType errorLevel="error"/>
+		<MoreSpecificReturnType errorLevel="error"/>
 	</issueHandlers>
 </psalm>

--- a/vendor-bin/openapi-extractor/composer.json
+++ b/vendor-bin/openapi-extractor/composer.json
@@ -1,0 +1,11 @@
+{
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/nextcloud/openapi-extractor"
+		}
+	],
+	"require-dev": {
+		"nextcloud/openapi-extractor": "dev-main"
+	}
+}

--- a/vendor-bin/openapi-extractor/composer.json
+++ b/vendor-bin/openapi-extractor/composer.json
@@ -5,7 +5,12 @@
 			"url": "https://github.com/nextcloud/openapi-extractor"
 		}
 	],
+	"config": {
+		"platform": {
+			"php": "8.1"
+		}
+	},
 	"require-dev": {
-		"nextcloud/openapi-extractor": "dev-main"
+		"nextcloud/openapi-extractor": "dev-main#c0c80648c1d7ede03537460dfbc472ff7146f294"
 	}
 }

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -1,0 +1,232 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ed3d2e9a9ffd1704ee84fea84debe5f1",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "adhocore/cli",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/adhocore/php-cli.git",
+                "reference": "25b5a93e5eebcdb70e20ee33313a011ea3a4f770"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/25b5a93e5eebcdb70e20ee33313a011ea3a4f770",
+                "reference": "25b5a93e5eebcdb70e20ee33313a011ea3a4f770",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ahc\\Cli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jitendra Adhikari",
+                    "email": "jiten.adhikary@gmail.com"
+                }
+            ],
+            "description": "Command line interface library for PHP",
+            "keywords": [
+                "argument-parser",
+                "argv-parser",
+                "cli",
+                "cli-action",
+                "cli-app",
+                "cli-color",
+                "cli-option",
+                "cli-writer",
+                "command",
+                "console",
+                "console-app",
+                "php-cli",
+                "php8",
+                "stream-input",
+                "stream-output"
+            ],
+            "support": {
+                "issues": "https://github.com/adhocore/php-cli/issues",
+                "source": "https://github.com/adhocore/php-cli/tree/v1.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/ji10",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/adhocore",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-06-26T09:55:29+00:00"
+        },
+        {
+            "name": "nextcloud/openapi-extractor",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nextcloud/openapi-extractor.git",
+                "reference": "aef9a921bebdcdc42b110a51bfb1e2ca281c307a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/aef9a921bebdcdc42b110a51bfb1e2ca281c307a",
+                "reference": "aef9a921bebdcdc42b110a51bfb1e2ca281c307a",
+                "shasum": ""
+            },
+            "require": {
+                "adhocore/cli": "^v1.6",
+                "ext-simplexml": "*",
+                "nikic/php-parser": "^4.16",
+                "php": "^8.1",
+                "phpstan/phpdoc-parser": "^1.23"
+            },
+            "default-branch": true,
+            "bin": [
+                "generate-spec",
+                "merge-specs"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenAPIExtractor\\": "src"
+                }
+            },
+            "support": {
+                "source": "https://github.com/nextcloud/openapi-extractor/tree/main",
+                "issues": "https://github.com/nextcloud/openapi-extractor/issues"
+            },
+            "time": "2023-10-06T05:18:46+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+            },
+            "time": "2023-08-13T19:53:39+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.24.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bcad8d995980440892759db0c32acae7c8e79442",
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.2"
+            },
+            "time": "2023-09-26T12:28:12+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "nextcloud/openapi-extractor": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed3d2e9a9ffd1704ee84fea84debe5f1",
+    "content-hash": "4610ce9186d2900b4d67c32cbc07ff25",
     "packages": [],
     "packages-dev": [
         {
@@ -83,12 +83,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/openapi-extractor.git",
-                "reference": "aef9a921bebdcdc42b110a51bfb1e2ca281c307a"
+                "reference": "c0c80648c1d7ede03537460dfbc472ff7146f294"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/aef9a921bebdcdc42b110a51bfb1e2ca281c307a",
-                "reference": "aef9a921bebdcdc42b110a51bfb1e2ca281c307a",
+                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/c0c80648c1d7ede03537460dfbc472ff7146f294",
+                "reference": "c0c80648c1d7ede03537460dfbc472ff7146f294",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "source": "https://github.com/nextcloud/openapi-extractor/tree/main",
                 "issues": "https://github.com/nextcloud/openapi-extractor/issues"
             },
-            "time": "2023-10-06T05:18:46+00:00"
+            "time": "2023-10-22T11:00:21+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -228,5 +228,8 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Copied over from https://github.com/nextcloud/server/pull/40744

API allowing clients to report sync problems to the server.

- [x] Add a capability
- [x] Fix the migration version
- [ ] Get rid of references to OC somehow
- [x] Add openapi
- [x] Needs https://github.com/nextcloud/server/pull/41017